### PR TITLE
Delay client notification until hotpatch artifact is ready

### DIFF
--- a/packages/cli/src/serve/runner.rs
+++ b/packages/cli/src/serve/runner.rs
@@ -493,7 +493,6 @@ impl AppServer {
                 }
                 self.clear_hot_reload_changes();
                 self.clear_cached_rsx();
-                server.send_patch_start().await;
             } else {
                 self.client.start_rebuild(BuildMode::Base { run: true });
                 if let Some(server) = self.server.as_mut() {


### PR DESCRIPTION
## Summary
- wait for hotpatch wasm to exist before notifying clients
- remove early `send_patch_start` call from runner

## Testing
- `cargo test -p dioxus-cli`


------
https://chatgpt.com/codex/tasks/task_e_68ab1f87e854832c8293458cbfebe3af